### PR TITLE
Add serde default attribute and u64/string serialization for tonic proto

### DIFF
--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.common.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.common.v1.rs
@@ -54,6 +54,7 @@ pub mod any_value {
 pub struct ArrayValue {
     /// Array of values. The array may be empty (contain 0 elements).
     #[prost(message, repeated, tag = "1")]
+    #[cfg_attr(feature = "with-serde", serde(default))]
     pub values: ::prost::alloc::vec::Vec<AnyValue>,
 }
 /// KeyValueList is a list of KeyValue messages. We need KeyValueList as a message
@@ -71,6 +72,7 @@ pub struct KeyValueList {
     /// The keys MUST be unique (it is not allowed to have more than one
     /// value with the same key).
     #[prost(message, repeated, tag = "1")]
+    #[cfg_attr(feature = "with-serde", serde(default))]
     pub values: ::prost::alloc::vec::Vec<KeyValue>,
 }
 /// KeyValue is a key-value pair that is used to store Span attributes, Link

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.metrics.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.metrics.v1.rs
@@ -715,6 +715,7 @@ pub struct Exemplar {
     /// recorded alongside the original measurement. Only key/value pairs that were
     /// filtered out by the aggregator should be included
     #[prost(message, repeated, tag = "7")]
+    #[cfg_attr(feature = "with-serde", serde(default))]
     pub filtered_attributes: ::prost::alloc::vec::Vec<
         super::super::common::v1::KeyValue,
     >,
@@ -723,6 +724,13 @@ pub struct Exemplar {
     /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
     /// 1970.
     #[prost(fixed64, tag = "2")]
+    #[cfg_attr(
+        feature = "with-serde",
+        serde(
+            serialize_with = "crate::proto::serializers::serialize_u64_to_string",
+            deserialize_with = "crate::proto::serializers::deserialize_string_to_u64"
+        )
+    )]
     pub time_unix_nano: u64,
     /// (Optional) Span ID of the exemplar trace.
     /// span_id may be missing if the measurement is not recorded inside a trace


### PR DESCRIPTION


OTLP Logs and Metrics requests can miss the fields shown below and I need to add default value for them when in deserialization.
Add string_to_u64 for parsing timestamp. 

